### PR TITLE
Work in progress commit for peer review

### DIFF
--- a/gocite.go
+++ b/gocite.go
@@ -440,20 +440,27 @@ func SortPassages(work Work) (Work, error) {
 		} else {
 			log.Println("*** I'm the first. ***")
 		}
-		if index == lastIndex { //if the cursor points to the last index
+		//if index == lastIndex { //if the cursor points to the last index
+		if work.Passages[cursor].PassageID == work.Last.PassageID {
 			last = true //mark it in the last variable
 			log.Println("*** I'm the last.  ***")
 		}
 		if last == false { //if this is not the last Passage in the work
-			tempPassage.Next.Index = index + 1                                        //set the Next index field to one higher than the current index
-			nextCursor, _ := GetIndexByID(work.Passages[cursor].Next.PassageID, work) //get the Index of the next Passage according to what is saved in the Passage.PassageID the cursor currently points to
-			cursor = nextCursor                                                       //set the cursor to the index of the next Passage
-			index++                                                                   //increment the index variable
+			tempPassage.Next.Index = index + 1 //set the Next index field to one higher than the current index
+			cursor = work.Passages[cursor].Next.Index
+			/*nextCursor, _ := GetIndexByID(work.Passages[cursor].Next.PassageID, work) //get the Index of the next Passage according to what is saved in the Passage.PassageID the cursor currently points to
+			cursor = nextCursor*/ //set the cursor to the index of the next Passage
+			index++               //increment the index variable
 		}
 		result.Passages = append(result.Passages, tempPassage) //append the temporary Passage to the resulting work
 	}
 	result.First = PassLoc{Exists: true, PassageID: result.Passages[0].PassageID, Index: 0}
 	result.Passages[0].Prev = PassLoc{}
+	lastIndex, found = FindLastIndex(result)
+	if !found {
+		log.Println("Last Index not found in result")
+		return work, errors.New("SortPassages: Last Index not found in result " + work.WorkID)
+	}
 	result.Last = PassLoc{Exists: true, PassageID: result.Passages[lastIndex].PassageID, Index: lastIndex}
 	result.Passages[lastIndex].Next = PassLoc{}
 	log.Println("*** Sorting finished. ***")

--- a/gocite.go
+++ b/gocite.go
@@ -440,17 +440,14 @@ func SortPassages(work Work) (Work, error) {
 		} else {
 			log.Println("*** I'm the first. ***")
 		}
-		//if index == lastIndex { //if the cursor points to the last index
-		if work.Passages[cursor].PassageID == work.Last.PassageID {
+		if work.Passages[cursor].PassageID == work.Last.PassageID { //if the cursor points to the last index
 			last = true //mark it in the last variable
 			log.Println("*** I'm the last.  ***")
 		}
 		if last == false { //if this is not the last Passage in the work
 			tempPassage.Next.Index = index + 1 //set the Next index field to one higher than the current index
 			cursor = work.Passages[cursor].Next.Index
-			/*nextCursor, _ := GetIndexByID(work.Passages[cursor].Next.PassageID, work) //get the Index of the next Passage according to what is saved in the Passage.PassageID the cursor currently points to
-			cursor = nextCursor*/ //set the cursor to the index of the next Passage
-			index++               //increment the index variable
+			index++ //increment the index variable
 		}
 		result.Passages = append(result.Passages, tempPassage) //append the temporary Passage to the resulting work
 	}

--- a/gocite.go
+++ b/gocite.go
@@ -373,7 +373,7 @@ func FindLastIndex(work Work) (int, bool) {
 //This is necessary for the first analysis of a work. For example in SortPassages.
 func FindLastIndex(work Work) (int, bool) {
 	for i := len(work.Passages) - 1; i >= 0; i-- {
-		if work.Passages[i].Prev.Exists == true && work.Passages[i].Next.Exists == false {
+		if (work.Passages[i].Prev.Exists == true && work.Passages[i].Next.Exists) == false {
 			return work.Passages[i].Index, true
 		}
 	}

--- a/gocite_test.go
+++ b/gocite_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ThomasK81/gocite"
 )
 
-type testPassage struct {
+type oldTestPassage struct {
 	PassageID               string
 	Range                   bool
 	Text                    gocite.EncText
@@ -14,27 +14,48 @@ type testPassage struct {
 	First, Last, Prev, Next gocite.PassLoc
 }
 
-type testWork struct {
+type newTestPassage struct {
+	PassageID  string
+	Range      bool
+	Text       gocite.EncText
+	Index      int
+	Prev, Next gocite.PassLoc
+}
+
+type oldTestWork struct {
 	WorkID   string
-	Passages []testPassage
+	Passages []oldTestPassage
 	Ordered  bool
 }
 
-type testpair struct {
+type newTestWork struct {
+	WorkID      string
+	Passages    []oldTestPassage
+	Ordered     bool
+	First, Last gocite.PassLoc
+}
+
+type URNTestpair struct {
 	input                  string
 	outputSplit            gocite.CTSURN
 	outputRange, outputCTS bool
 }
 
-type testpair2 struct {
+type testIDfeaturesTestpair struct {
 	input                                        string
 	outputTG, outputWork, outputVers, outputExmp bool
 }
 
-type testgroup struct {
-	inputcorpus gocite.Work
-	inputID     string
-	output      gocite.Work
+type oldWorkTestgroup struct {
+	inputCorpus  oldTestWork
+	inputID      string
+	outputCorpus oldTestWork
+}
+
+type newWorkTestgroup struct {
+	inputCorpus  gocite.Work
+	inputID      string
+	outputCorpus gocite.Work
 }
 
 type extractgroup struct {
@@ -42,19 +63,19 @@ type extractgroup struct {
 	answer []gocite.TextAndID
 }
 
-var tests = []testpair{
+var URNtests = []URNTestpair{
 	{input: "urn:cts:collection:workgroup.work:1-27", outputSplit: gocite.CTSURN{ID: "urn:cts:collection:workgroup.work:1-27", Base: "urn", Protocol: "cts", Namespace: "collection", Work: "workgroup.work", Passage: "1-27"}, outputRange: true, outputCTS: true},
 	{input: "urn:cts:collection:workgroup.work:27.3", outputSplit: gocite.CTSURN{ID: "urn:cts:collection:workgroup.work:27.3", Base: "urn", Protocol: "cts", Namespace: "collection", Work: "workgroup.work", Passage: "27.3"}, outputRange: false, outputCTS: true},
 	{input: "not:cts:collection:workgroup.work:27.3", outputSplit: gocite.CTSURN{ID: "not:cts:collection:workgroup.work:27.3", InValid: true}, outputRange: false, outputCTS: false}}
 
-var tests2 = []testpair2{
+var IDfeatureTests = []testIDfeaturesTestpair{
 	{input: "urn:cts:collection:workgroup:", outputTG: true, outputWork: false, outputVers: false, outputExmp: false},
 	{input: "urn:cts:collection:workgroup.work:27.3", outputTG: false, outputWork: true, outputVers: false, outputExmp: false},
 	{input: "urn:cts:collection:workgroup.work.version:27.3-29.9", outputTG: false, outputWork: false, outputVers: true, outputExmp: false},
 	{input: "urn:cts:collection:workgroup.work.version.exemplar:29.9", outputTG: false, outputWork: false, outputVers: false, outputExmp: true},
 }
 
-var firstPassage = gocite.Passage{
+var oldFirstPassage = oldTestPassage{
 	PassageID: "urn:cts:collection:workgroup.work:1",
 	Range:     false,
 	Text: gocite.EncText{
@@ -67,7 +88,18 @@ var firstPassage = gocite.Passage{
 	Next:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:2-4", Index: 1},
 }
 
-var firstPassageChange = gocite.Passage{
+var newFirstPassage = gocite.Passage{
+	PassageID: "urn:cts:collection:workgroup.work:1",
+	Range:     false,
+	Text: gocite.EncText{
+		TXT: "This is the first node.",
+	},
+	Index: 0,
+	Prev:  gocite.PassLoc{Exists: false, PassageID: "", Index: 0},
+	Next:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:2-4", Index: 1},
+}
+
+var oldFirstPassageChange = oldTestPassage{
 	PassageID: "urn:cts:collection:workgroup.work:1",
 	Range:     false,
 	Text: gocite.EncText{
@@ -80,20 +112,18 @@ var firstPassageChange = gocite.Passage{
 	Next:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:5", Index: 2},
 }
 
-var thirdPassageChange = gocite.Passage{
-	PassageID: "urn:cts:collection:workgroup.work:5",
+var newFirstPassageChange = gocite.Passage{
+	PassageID: "urn:cts:collection:workgroup.work:1",
 	Range:     false,
 	Text: gocite.EncText{
-		TXT: "This is the third node.",
+		TXT: "This is the first node.",
 	},
-	Index: 2,
-	First: gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
-	Last:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:5", Index: 2},
-	Next:  gocite.PassLoc{Exists: false, PassageID: "", Index: 0},
-	Prev:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
+	Index: 0,
+	Prev:  gocite.PassLoc{Exists: false, PassageID: "", Index: 0},
+	Next:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:5", Index: 2},
 }
 
-var secondPassage = gocite.Passage{
+var oldSecondPassage = oldTestPassage{
 	PassageID: "urn:cts:collection:workgroup.work:2-4",
 	Range:     false,
 	Text: gocite.EncText{
@@ -106,7 +136,18 @@ var secondPassage = gocite.Passage{
 	Next:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:5", Index: 2},
 }
 
-var thirdPassage = gocite.Passage{
+var newSecondPassage = gocite.Passage{
+	PassageID: "urn:cts:collection:workgroup.work:2-4",
+	Range:     false,
+	Text: gocite.EncText{
+		TXT: "This is. the second. node.",
+	},
+	Index: 1,
+	Prev:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
+	Next:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:5", Index: 2},
+}
+
+var oldThirdPassage = oldTestPassage{
 	PassageID: "urn:cts:collection:workgroup.work:5",
 	Range:     false,
 	Text: gocite.EncText{
@@ -119,99 +160,224 @@ var thirdPassage = gocite.Passage{
 	Prev:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:2-4", Index: 1},
 }
 
-var testcorpus = gocite.Work{
+var newThirdPassage = gocite.Passage{
+	PassageID: "urn:cts:collection:workgroup.work:5",
+	Range:     false,
+	Text: gocite.EncText{
+		TXT: "This is the third node.",
+	},
+	Index: 2,
+	Next:  gocite.PassLoc{Exists: false, PassageID: "", Index: 0},
+	Prev:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:2-4", Index: 1},
+}
+
+var oldThirdPassageChange = oldTestPassage{
+	PassageID: "urn:cts:collection:workgroup.work:5",
+	Range:     false,
+	Text: gocite.EncText{
+		TXT: "This is the third node.",
+	},
+	Index: 2,
+	First: gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
+	Last:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:5", Index: 2},
+	Next:  gocite.PassLoc{Exists: false, PassageID: "", Index: 0},
+	Prev:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
+}
+
+var newThirdPassageChange = gocite.Passage{
+	PassageID: "urn:cts:collection:workgroup.work:5",
+	Range:     false,
+	Text: gocite.EncText{
+		TXT: "This is the third node.",
+	},
+	Index: 2,
+	Next:  gocite.PassLoc{Exists: false, PassageID: "", Index: 0},
+	Prev:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
+}
+
+var oldTestcorpus = oldTestWork{
 	WorkID: "urn:cts:collection:workgroup.work:",
-	Passages: []gocite.Passage{
-		firstPassage,
-		secondPassage,
-		thirdPassage,
+	Passages: []oldTestPassage{
+		oldFirstPassage,
+		oldSecondPassage,
+		oldThirdPassage,
 	},
 	Ordered: true,
 }
 
-var testcorpus2 = gocite.Work{
+var newTestcorpus = gocite.Work{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
-		firstPassageChange,
+		newFirstPassage,
+		newSecondPassage,
+		newThirdPassage,
+	},
+	First:   gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
+	Last:    gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:5", Index: 2},
+	Ordered: true,
+}
+
+var oldTestcorpus2 = oldTestWork{
+	WorkID: "urn:cts:collection:workgroup.work:",
+	Passages: []oldTestPassage{
+		oldFirstPassageChange,
 		{},
-		thirdPassageChange,
+		oldThirdPassageChange,
 	},
 	Ordered: false}
 
-var testcorpus3 = gocite.Work{
+var newTestcorpus2 = gocite.Work{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
-		{PassageID: firstPassageChange.PassageID, Range: firstPassageChange.Range, Text: firstPassageChange.Text, Index: 0, First: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 1}, Next: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 1}},
-		{PassageID: thirdPassageChange.PassageID, Range: thirdPassageChange.Range, Text: thirdPassageChange.Text, Index: 1, First: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 1}, Prev: gocite.PassLoc{Exists: true, PassageID: firstPassage.PassageID, Index: 0}},
+		newFirstPassageChange,
+		{},
+		newThirdPassageChange,
+	},
+	First:   gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
+	Last:    gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:5", Index: 2},
+	Ordered: false}
+
+var oldTestcorpus3 = oldTestWork{
+	WorkID: "urn:cts:collection:workgroup.work:",
+	Passages: []oldTestPassage{
+		{PassageID: oldFirstPassageChange.PassageID, Range: oldFirstPassageChange.Range, Text: oldFirstPassageChange.Text, Index: 0, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}, Next: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}},
+		{PassageID: oldThirdPassageChange.PassageID, Range: oldThirdPassageChange.Range, Text: oldThirdPassageChange.Text, Index: 1, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}, Prev: gocite.PassLoc{Exists: true, PassageID: oldFirstPassage.PassageID, Index: 0}},
 	},
 	Ordered: true}
 
-var testcorpus4 = gocite.Work{
+var newTestcorpus3 = gocite.Work{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
-		firstPassageChange,
-		thirdPassageChange,
+		{PassageID: newFirstPassageChange.PassageID, Range: newFirstPassageChange.Range, Text: newFirstPassageChange.Text, Index: 0, Next: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}},
+		{PassageID: newThirdPassageChange.PassageID, Range: newThirdPassageChange.Range, Text: newThirdPassageChange.Text, Index: 1, Prev: gocite.PassLoc{Exists: true, PassageID: oldFirstPassage.PassageID, Index: 0}},
+	},
+	First:   gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0},
+	Last:    gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1},
+	Ordered: true}
+
+var oldTestcorpus4 = oldTestWork{
+	WorkID: "urn:cts:collection:workgroup.work:",
+	Passages: []oldTestPassage{
+		oldFirstPassageChange,
+		oldThirdPassageChange,
 	},
 	Ordered: true}
 
-var testcorpus5 = gocite.Work{
+var newTestcorpus4 = gocite.Work{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
-		{PassageID: firstPassageChange.PassageID, Range: firstPassageChange.Range, Text: firstPassageChange.Text, Index: 0, First: firstPassageChange.First, Last: firstPassageChange.Last, Prev: firstPassageChange.Prev, Next: gocite.PassLoc{Exists: true, PassageID: secondPassage.PassageID, Index: 2}},
-		{PassageID: thirdPassageChange.PassageID, Range: thirdPassageChange.Range, Text: thirdPassageChange.Text, Index: 1, First: firstPassageChange.First, Last: firstPassageChange.Last, Prev: gocite.PassLoc{Exists: true, PassageID: secondPassage.PassageID, Index: 2}, Next: gocite.PassLoc{}},
-		{PassageID: secondPassage.PassageID, Range: secondPassage.Range, Text: secondPassage.Text, Index: 2, First: thirdPassageChange.First, Last: thirdPassageChange.Last, Prev: thirdPassageChange.First, Next: gocite.PassLoc{Exists: true, PassageID: thirdPassage.PassageID, Index: 1}},
+		newFirstPassageChange,
+		newThirdPassageChange,
+	},
+	First:   gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0},
+	Last:    gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1},
+	Ordered: true}
+
+var oldTestcorpus5 = oldTestWork{
+	WorkID: "urn:cts:collection:workgroup.work:",
+	Passages: []oldTestPassage{
+		{PassageID: oldFirstPassageChange.PassageID, Range: oldFirstPassageChange.Range, Text: oldFirstPassageChange.Text, Index: 0, First: oldFirstPassageChange.First, Last: oldFirstPassageChange.Last, Prev: oldFirstPassageChange.Prev, Next: gocite.PassLoc{Exists: true, PassageID: oldSecondPassage.PassageID, Index: 2}},
+		{PassageID: oldThirdPassageChange.PassageID, Range: oldThirdPassageChange.Range, Text: oldThirdPassageChange.Text, Index: 1, First: oldFirstPassageChange.First, Last: oldFirstPassageChange.Last, Prev: gocite.PassLoc{Exists: true, PassageID: oldSecondPassage.PassageID, Index: 2}, Next: gocite.PassLoc{}},
+		{PassageID: oldSecondPassage.PassageID, Range: oldSecondPassage.Range, Text: oldSecondPassage.Text, Index: 2, First: oldThirdPassageChange.First, Last: oldThirdPassageChange.Last, Prev: oldThirdPassageChange.First, Next: gocite.PassLoc{Exists: true, PassageID: oldThirdPassage.PassageID, Index: 1}},
 	},
 	Ordered: false,
 }
 
-var testcorpus6 = gocite.Work{
+var newTestcorpus5 = gocite.Work{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
-		{PassageID: firstPassageChange.PassageID, Range: firstPassageChange.Range, Text: firstPassageChange.Text, Index: 0, First: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 2}, Next: gocite.PassLoc{Exists: true, PassageID: secondPassage.PassageID, Index: 1}},
-		{PassageID: secondPassage.PassageID, Range: secondPassage.Range, Text: secondPassage.Text, Index: 1, First: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 2}, Next: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 2}, Prev: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}},
-		{PassageID: thirdPassageChange.PassageID, Range: thirdPassageChange.Range, Text: thirdPassageChange.Text, Index: 2, First: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 2}, Prev: gocite.PassLoc{Exists: true, PassageID: secondPassage.PassageID, Index: 1}},
+		{PassageID: newFirstPassageChange.PassageID, Range: newFirstPassageChange.Range, Text: newFirstPassageChange.Text, Index: 0, Prev: newFirstPassageChange.Prev, Next: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 2}},
+		{PassageID: newThirdPassageChange.PassageID, Range: newThirdPassageChange.Range, Text: newThirdPassageChange.Text, Index: 1, Prev: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 2}, Next: gocite.PassLoc{}},
+		{PassageID: newSecondPassage.PassageID, Range: newSecondPassage.Range, Text: newSecondPassage.Text, Index: 2, Prev: gocite.PassLoc{Exists: true, PassageID: newThirdPassageChange.PassageID, Index: 0}, Next: gocite.PassLoc{Exists: true, PassageID: newThirdPassage.PassageID, Index: 1}},
+	},
+	First:   oldFirstPassageChange.First,
+	Last:    oldFirstPassageChange.Last,
+	Ordered: false,
+}
+
+var oldTestcorpus6 = oldTestWork{
+	WorkID: "urn:cts:collection:workgroup.work:",
+	Passages: []oldTestPassage{
+		{PassageID: oldFirstPassageChange.PassageID, Range: oldFirstPassageChange.Range, Text: oldFirstPassageChange.Text, Index: 0, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 2}, Next: gocite.PassLoc{Exists: true, PassageID: oldSecondPassage.PassageID, Index: 1}},
+		{PassageID: oldSecondPassage.PassageID, Range: oldSecondPassage.Range, Text: oldSecondPassage.Text, Index: 1, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 2}, Next: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 2}, Prev: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}},
+		{PassageID: oldThirdPassageChange.PassageID, Range: oldThirdPassageChange.Range, Text: oldThirdPassageChange.Text, Index: 2, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 2}, Prev: gocite.PassLoc{Exists: true, PassageID: oldSecondPassage.PassageID, Index: 1}},
 	},
 	Ordered: false,
 }
 
-var testcorpus7 = gocite.Work{
+var newTestcorpus6 = gocite.Work{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
-		{PassageID: firstPassageChange.PassageID, Range: false, Text: firstPassageChange.Text, Index: 0, First: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 1}, Next: gocite.PassLoc{Exists: true, PassageID: thirdPassage.PassageID, Index: 1}},
-		{PassageID: thirdPassageChange.PassageID, Range: false, Text: thirdPassageChange.Text, Index: 1, First: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 1}, Prev: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}},
+		{PassageID: newFirstPassageChange.PassageID, Range: newFirstPassageChange.Range, Text: newFirstPassageChange.Text, Index: 0, Next: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 1}},
+		{PassageID: newSecondPassage.PassageID, Range: newSecondPassage.Range, Text: newSecondPassage.Text, Index: 1, Next: gocite.PassLoc{Exists: true, PassageID: newThirdPassageChange.PassageID, Index: 2}, Prev: gocite.PassLoc{Exists: true, PassageID: newFirstPassageChange.PassageID, Index: 0}},
+		{PassageID: newThirdPassageChange.PassageID, Range: newThirdPassageChange.Range, Text: newThirdPassageChange.Text, Index: 2, Prev: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 1}},
+	},
+	First:   gocite.PassLoc{Exists: true, PassageID: newFirstPassageChange.PassageID, Index: 0},
+	Last:    gocite.PassLoc{Exists: true, PassageID: newThirdPassageChange.PassageID, Index: 2},
+	Ordered: false,
+}
+
+var oldTestcorpus7 = oldTestWork{
+	WorkID: "urn:cts:collection:workgroup.work:",
+	Passages: []oldTestPassage{
+		{PassageID: oldFirstPassageChange.PassageID, Range: false, Text: oldFirstPassageChange.Text, Index: 0, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}, Next: gocite.PassLoc{Exists: true, PassageID: oldThirdPassage.PassageID, Index: 1}},
+		{PassageID: oldThirdPassageChange.PassageID, Range: false, Text: oldThirdPassageChange.Text, Index: 1, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}, Prev: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}},
 	},
 	Ordered: true}
 
-var testcorpus8 = gocite.Work{
+var newTestcorpus7 = gocite.Work{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
-		{PassageID: firstPassageChange.PassageID, Range: false, Text: firstPassageChange.Text, Index: 0, First: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 1}, Next: gocite.PassLoc{Exists: true, PassageID: secondPassage.PassageID, Index: 2}},
-		{PassageID: thirdPassageChange.PassageID, Range: false, Text: thirdPassageChange.Text, Index: 1, First: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 1}, Prev: gocite.PassLoc{Exists: true, PassageID: secondPassage.PassageID, Index: 2}},
-		{PassageID: secondPassage.PassageID, Range: secondPassage.Range, Text: secondPassage.Text, Index: 2, First: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 1}, Prev: gocite.PassLoc{Exists: true, PassageID: firstPassageChange.PassageID, Index: 0}, Next: gocite.PassLoc{Exists: true, PassageID: thirdPassageChange.PassageID, Index: 1}},
+		{PassageID: newFirstPassageChange.PassageID, Range: false, Text: newFirstPassageChange.Text, Index: 0, Next: gocite.PassLoc{Exists: true, PassageID: newThirdPassage.PassageID, Index: 1}},
+		{PassageID: newThirdPassageChange.PassageID, Range: false, Text: newThirdPassageChange.Text, Index: 1, Prev: gocite.PassLoc{Exists: true, PassageID: newFirstPassageChange.PassageID, Index: 0}},
+	},
+	First:   gocite.PassLoc{Exists: true, PassageID: newFirstPassageChange.PassageID, Index: 0},
+	Last:    gocite.PassLoc{Exists: true, PassageID: newThirdPassageChange.PassageID, Index: 1},
+	Ordered: true}
+
+var oldTestcorpus8 = oldTestWork{
+	WorkID: "urn:cts:collection:workgroup.work:",
+	Passages: []oldTestPassage{
+		{PassageID: oldFirstPassageChange.PassageID, Range: false, Text: oldFirstPassageChange.Text, Index: 0, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}, Next: gocite.PassLoc{Exists: true, PassageID: oldSecondPassage.PassageID, Index: 2}},
+		{PassageID: oldThirdPassageChange.PassageID, Range: false, Text: oldThirdPassageChange.Text, Index: 1, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}, Prev: gocite.PassLoc{Exists: true, PassageID: oldSecondPassage.PassageID, Index: 2}},
+		{PassageID: oldSecondPassage.PassageID, Range: oldSecondPassage.Range, Text: oldSecondPassage.Text, Index: 2, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}, Prev: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Next: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}},
 	},
 	Ordered: false,
 }
 
-var tests3 = []testgroup{
-	{inputcorpus: testcorpus, inputID: "urn:cts:collection:workgroup.work:2-4", output: testcorpus2},
+var newTestcorpus8 = gocite.Work{
+	WorkID: "urn:cts:collection:workgroup.work:",
+	Passages: []gocite.Passage{
+		{PassageID: newFirstPassageChange.PassageID, Range: false, Text: newFirstPassageChange.Text, Index: 0, Next: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 2}},
+		{PassageID: newThirdPassageChange.PassageID, Range: false, Text: newThirdPassageChange.Text, Index: 1, Prev: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 2}},
+		{PassageID: newSecondPassage.PassageID, Range: newSecondPassage.Range, Text: newSecondPassage.Text, Index: 2, Next: gocite.PassLoc{Exists: true, PassageID: newThirdPassageChange.PassageID, Index: 1}},
+	},
+
+	First:   gocite.PassLoc{Exists: true, PassageID: newFirstPassageChange.PassageID, Index: 0},
+	Last:    gocite.PassLoc{Exists: true, PassageID: newThirdPassageChange.PassageID, Index: 1},
+	Ordered: false,
 }
 
-var tests4a = []testgroup{
-	{inputcorpus: testcorpus3, inputID: firstPassageChange.First.PassageID},
-	{inputcorpus: testcorpus5, inputID: firstPassageChange.First.PassageID},
+var URNtests3 = []oldWorkTestgroup{
+	{inputCorpus: oldTestcorpus, inputID: "urn:cts:collection:workgroup.work:2-4", outputCorpus: oldTestcorpus2},
 }
 
-var tests4 = []testgroup{
-	{inputcorpus: testcorpus2, output: testcorpus3},
-	{inputcorpus: testcorpus5, output: testcorpus6},
+var URNtests4a = []oldWorkTestgroup{
+	{inputCorpus: oldTestcorpus3, inputID: oldFirstPassageChange.First.PassageID},
+	{inputCorpus: oldTestcorpus5, inputID: oldFirstPassageChange.First.PassageID},
 }
 
-var tests5 = []testgroup{
-	{inputcorpus: testcorpus7, output: testcorpus8},
+var URNtests4 = []oldWorkTestgroup{
+	{inputCorpus: oldTestcorpus2, outputCorpus: oldTestcorpus3},
+	{inputCorpus: oldTestcorpus5, outputCorpus: oldTestcorpus6},
+}
+
+var URNtests5 = []oldWorkTestgroup{
+	{inputCorpus: oldTestcorpus7, outputCorpus: oldTestcorpus8},
 }
 
 func TestSplitCTS(t *testing.T) {
-	for _, pair := range tests {
+	for _, pair := range URNtests {
 		v := gocite.SplitCTS(pair.input)
 		if v != pair.outputSplit {
 			t.Error(
@@ -224,7 +390,7 @@ func TestSplitCTS(t *testing.T) {
 }
 
 func TestIsRange(t *testing.T) {
-	for _, pair := range tests {
+	for _, pair := range URNtests {
 		v := gocite.IsRange(pair.input)
 		if v != pair.outputRange {
 			t.Error(
@@ -237,7 +403,7 @@ func TestIsRange(t *testing.T) {
 }
 
 func TestIsCTSURN(t *testing.T) {
-	for _, pair := range tests {
+	for _, pair := range URNtests {
 		v := gocite.IsCTSURN(pair.input)
 		if v != pair.outputCTS {
 			t.Error(
@@ -250,7 +416,7 @@ func TestIsCTSURN(t *testing.T) {
 }
 
 func TestIsTextgroupID(t *testing.T) {
-	for _, pair := range tests2 {
+	for _, pair := range IDfeatureTests {
 		v := gocite.IsTextgroupID(pair.input)
 		if v != pair.outputTG {
 			t.Error(
@@ -263,7 +429,7 @@ func TestIsTextgroupID(t *testing.T) {
 }
 
 func TestIsWorkID(t *testing.T) {
-	for _, pair := range tests2 {
+	for _, pair := range IDfeatureTests {
 		v := gocite.IsWorkID(pair.input)
 		if v != pair.outputWork {
 			t.Error(
@@ -276,7 +442,7 @@ func TestIsWorkID(t *testing.T) {
 }
 
 func TestIsVersionID(t *testing.T) {
-	for _, pair := range tests2 {
+	for _, pair := range IDfeatureTests {
 		v := gocite.IsVersionID(pair.input)
 		if v != pair.outputVers {
 			t.Error(
@@ -289,7 +455,7 @@ func TestIsVersionID(t *testing.T) {
 }
 
 func TestIsExemplarID(t *testing.T) {
-	for _, pair := range tests2 {
+	for _, pair := range IDfeatureTests {
 		v := gocite.IsExemplarID(pair.input)
 		if v != pair.outputExmp {
 			t.Error(
@@ -302,10 +468,10 @@ func TestIsExemplarID(t *testing.T) {
 }
 
 func TestDelPassage(t *testing.T) {
-	for _, pair := range tests3 {
-		v := gocite.DelPassage(pair.inputID, pair.inputcorpus)
-		baseWork := testWork{Ordered: v.Ordered}
-		compareWork := testWork{Ordered: pair.inputcorpus.Ordered}
+	for _, pair := range URNtests3 {
+		v, _ := gocite.DelPassage(pair.inputID, pair.inputcorpus)
+		baseWork := oldTestWork{Ordered: v.Ordered}
+		compareWork := oldTestWork{Ordered: pair.inputcorpus.Ordered}
 		if baseWork.Ordered == compareWork.Ordered {
 			t.Error(
 				"For deleting", pair.inputID,
@@ -314,7 +480,7 @@ func TestDelPassage(t *testing.T) {
 			)
 		}
 		for i := range v.Passages {
-			basePassage := testPassage{PassageID: v.Passages[i].PassageID,
+			basePassage := oldTestPassage{PassageID: v.Passages[i].PassageID,
 				Range: v.Passages[i].Range,
 				Text:  v.Passages[i].Text,
 				Index: v.Passages[i].Index,
@@ -322,7 +488,7 @@ func TestDelPassage(t *testing.T) {
 				Last:  v.Passages[i].Last,
 				Prev:  v.Passages[i].Prev,
 				Next:  v.Passages[i].Next}
-			comparePassage := testPassage{PassageID: pair.output.Passages[i].PassageID,
+			comparePassage := oldTestPassage{PassageID: pair.output.Passages[i].PassageID,
 				Range: pair.output.Passages[i].Range,
 				Text:  pair.output.Passages[i].Text,
 				Index: pair.output.Passages[i].Index,
@@ -342,7 +508,7 @@ func TestDelPassage(t *testing.T) {
 }
 
 func TestFindFirstIndex(t *testing.T) {
-	for _, pair := range tests4a {
+	for _, pair := range URNtests4a {
 		v, found := gocite.FindFirstIndex(pair.inputcorpus)
 		if found != true {
 			t.Error(
@@ -362,7 +528,7 @@ func TestFindFirstIndex(t *testing.T) {
 }
 
 func TestSortPassages(t *testing.T) {
-	for j, pair := range tests4 {
+	for j, pair := range URNtests4 {
 		v := gocite.SortPassages(pair.inputcorpus)
 		if v.Ordered == false {
 			t.Error(
@@ -372,7 +538,7 @@ func TestSortPassages(t *testing.T) {
 			)
 		}
 		for i := range v.Passages {
-			basePassage := testPassage{PassageID: v.Passages[i].PassageID,
+			basePassage := oldTestPassage{PassageID: v.Passages[i].PassageID,
 				Range: v.Passages[i].Range,
 				Text:  v.Passages[i].Text,
 				Index: v.Passages[i].Index,
@@ -380,7 +546,7 @@ func TestSortPassages(t *testing.T) {
 				Last:  v.Passages[i].Last,
 				Prev:  v.Passages[i].Prev,
 				Next:  v.Passages[i].Next}
-			comparePassage := testPassage{PassageID: pair.output.Passages[i].PassageID,
+			comparePassage := oldTestPassage{PassageID: pair.output.Passages[i].PassageID,
 				Range: pair.output.Passages[i].Range,
 				Text:  pair.output.Passages[i].Text,
 				Index: pair.output.Passages[i].Index,
@@ -400,7 +566,7 @@ func TestSortPassages(t *testing.T) {
 }
 
 func TestInsertPassage(t *testing.T) {
-	v := gocite.InsertPassage(secondPassage, tests5[0].inputcorpus)
+	v := gocite.InsertPassage(oldSecondPassage, URNtests5[0].inputcorpus)
 	if v.Ordered == true {
 		t.Error(
 			"Expected ordered", false,
@@ -408,7 +574,7 @@ func TestInsertPassage(t *testing.T) {
 		)
 	}
 	for i := range v.Passages {
-		basePassage := testPassage{PassageID: v.Passages[i].PassageID,
+		basePassage := oldTestPassage{PassageID: v.Passages[i].PassageID,
 			Range: v.Passages[i].Range,
 			Text:  v.Passages[i].Text,
 			Index: v.Passages[i].Index,
@@ -416,18 +582,18 @@ func TestInsertPassage(t *testing.T) {
 			Last:  v.Passages[i].Last,
 			Prev:  v.Passages[i].Prev,
 			Next:  v.Passages[i].Next}
-		comparePassage := testPassage{PassageID: tests5[0].output.Passages[i].PassageID,
-			Range: tests5[0].output.Passages[i].Range,
-			Text:  tests5[0].output.Passages[i].Text,
-			Index: tests5[0].output.Passages[i].Index,
-			First: tests5[0].output.Passages[i].First,
-			Last:  tests5[0].output.Passages[i].Last,
-			Prev:  tests5[0].output.Passages[i].Prev,
-			Next:  tests5[0].output.Passages[i].Next}
+		comparePassage := oldTestPassage{PassageID: URNtests5[0].output.Passages[i].PassageID,
+			Range: URNtests5[0].output.Passages[i].Range,
+			Text:  URNtests5[0].output.Passages[i].Text,
+			Index: URNtests5[0].output.Passages[i].Index,
+			First: URNtests5[0].output.Passages[i].First,
+			Last:  URNtests5[0].output.Passages[i].Last,
+			Prev:  URNtests5[0].output.Passages[i].Prev,
+			Next:  URNtests5[0].output.Passages[i].Next}
 		if basePassage != comparePassage {
 			t.Error(
 				"For test", i,
-				"expected", tests5[0].output.Passages[i],
+				"expected", URNtests5[0].output.Passages[i],
 				"got", v.Passages[i],
 			)
 		}

--- a/gocite_test.go
+++ b/gocite_test.go
@@ -195,6 +195,8 @@ var newThirdPassageChange = gocite.Passage{
 	Prev:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
 }
 
+//The testcorpora should get some more spelling names, according to the tasks they fulfill or possibly some documentation
+
 var oldTestcorpus = oldTestWork{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []oldTestPassage{
@@ -217,6 +219,7 @@ var newTestcorpus = gocite.Work{
 	Ordered: true,
 }
 
+//testcorpus2 is used to tests if sorting works with an empty passage in a work
 var oldTestcorpus2 = oldTestWork{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []oldTestPassage{
@@ -273,6 +276,7 @@ var newTestcorpus4 = gocite.Work{
 	Last:    gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1},
 	Ordered: true}
 
+//tescorpus5 is used to tests if sorting works with unordered passages in a work
 var oldTestcorpus5 = oldTestWork{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []oldTestPassage{
@@ -358,22 +362,40 @@ var newTestcorpus8 = gocite.Work{
 	Ordered: false,
 }
 
-var URNtests3 = []oldWorkTestgroup{
+var OldURNtests3 = []oldWorkTestgroup{ //slice format necessary?
 	{inputCorpus: oldTestcorpus, inputID: "urn:cts:collection:workgroup.work:2-4", outputCorpus: oldTestcorpus2},
 }
 
-var URNtests4a = []oldWorkTestgroup{
+var URNtests3 = []newWorkTestgroup{ //slice format necessary?
+	{inputCorpus: newTestcorpus, inputID: "urn:cts:collection:workgroup.work:2-4", outputCorpus: newTestcorpus2},
+}
+
+var oldURNtests4a = []oldWorkTestgroup{
 	{inputCorpus: oldTestcorpus3, inputID: oldFirstPassageChange.First.PassageID},
 	{inputCorpus: oldTestcorpus5, inputID: oldFirstPassageChange.First.PassageID},
 }
 
-var URNtests4 = []oldWorkTestgroup{
+var URNtests4a = []newWorkTestgroup{
+	{inputCorpus: newTestcorpus3, inputID: newTestcorpus3.First.PassageID},
+	{inputCorpus: newTestcorpus5, inputID: newTestcorpus5.First.PassageID},
+}
+
+var oldURNtests4 = []oldWorkTestgroup{
 	{inputCorpus: oldTestcorpus2, outputCorpus: oldTestcorpus3},
 	{inputCorpus: oldTestcorpus5, outputCorpus: oldTestcorpus6},
 }
 
-var URNtests5 = []oldWorkTestgroup{
+var URNtests4 = []newWorkTestgroup{
+	{inputCorpus: newTestcorpus2, outputCorpus: newTestcorpus3},
+	{inputCorpus: newTestcorpus5, outputCorpus: newTestcorpus6},
+}
+
+var oldTests5 = []oldWorkTestgroup{ //slice format necessary?
 	{inputCorpus: oldTestcorpus7, outputCorpus: oldTestcorpus8},
+}
+
+var URNtests5 = []newWorkTestgroup{ //slice format necessary?
+	{inputCorpus: newTestcorpus7, outputCorpus: newTestcorpus8},
 }
 
 func TestSplitCTS(t *testing.T) {
@@ -467,40 +489,36 @@ func TestIsExemplarID(t *testing.T) {
 	}
 }
 
-func TestDelPassage(t *testing.T) {
-	for _, pair := range URNtests3 {
-		v, _ := gocite.DelPassage(pair.inputID, pair.inputcorpus)
-		baseWork := oldTestWork{Ordered: v.Ordered}
-		compareWork := oldTestWork{Ordered: pair.inputcorpus.Ordered}
+func TestDePlassage(t *testing.T) {
+	for _, workTestgroup := range URNtests3 {
+		sortedWork, _ := gocite.DelPassage(workTestgroup.inputID, workTestgroup.inputCorpus)
+		baseWork := oldTestWork{Ordered: sortedWork.Ordered}
+		compareWork := oldTestWork{Ordered: workTestgroup.inputCorpus.Ordered}
 		if baseWork.Ordered == compareWork.Ordered {
 			t.Error(
-				"For deleting", pair.inputID,
-				"expected", !pair.inputcorpus.Ordered,
-				"got", pair.inputcorpus.Ordered,
+				"For deleting", workTestgroup.inputID,
+				"expected", !workTestgroup.inputCorpus.Ordered,
+				"got", workTestgroup.inputCorpus.Ordered,
 			)
 		}
-		for i := range v.Passages {
-			basePassage := oldTestPassage{PassageID: v.Passages[i].PassageID,
-				Range: v.Passages[i].Range,
-				Text:  v.Passages[i].Text,
-				Index: v.Passages[i].Index,
-				First: v.Passages[i].First,
-				Last:  v.Passages[i].Last,
-				Prev:  v.Passages[i].Prev,
-				Next:  v.Passages[i].Next}
-			comparePassage := oldTestPassage{PassageID: pair.output.Passages[i].PassageID,
-				Range: pair.output.Passages[i].Range,
-				Text:  pair.output.Passages[i].Text,
-				Index: pair.output.Passages[i].Index,
-				First: pair.output.Passages[i].First,
-				Last:  pair.output.Passages[i].Last,
-				Prev:  pair.output.Passages[i].Prev,
-				Next:  pair.output.Passages[i].Next}
+		for i := range sortedWork.Passages {
+			basePassage := newTestPassage{PassageID: sortedWork.Passages[i].PassageID,
+				Range: sortedWork.Passages[i].Range,
+				Text:  sortedWork.Passages[i].Text,
+				Index: sortedWork.Passages[i].Index,
+				Prev:  sortedWork.Passages[i].Prev,
+				Next:  sortedWork.Passages[i].Next}
+			comparePassage := newTestPassage{PassageID: workTestgroup.outputCorpus.Passages[i].PassageID,
+				Range: workTestgroup.outputCorpus.Passages[i].Range,
+				Text:  workTestgroup.outputCorpus.Passages[i].Text,
+				Index: workTestgroup.outputCorpus.Passages[i].Index,
+				Prev:  workTestgroup.outputCorpus.Passages[i].Prev,
+				Next:  workTestgroup.outputCorpus.Passages[i].Next}
 			if basePassage != comparePassage {
 				t.Error(
-					"For deleting", pair.inputID,
-					"expected", pair.output.Passages[i],
-					"got", v.Passages[i],
+					"For deleting passage with ID ", workTestgroup.inputID,
+					" expected remaining passage", workTestgroup.outputCorpus.Passages[i],
+					", but got passage ", sortedWork.Passages[i], " instead",
 				)
 			}
 		}
@@ -509,56 +527,109 @@ func TestDelPassage(t *testing.T) {
 
 func TestFindFirstIndex(t *testing.T) {
 	for _, pair := range URNtests4a {
-		v, found := gocite.FindFirstIndex(pair.inputcorpus)
+		v, found := gocite.FindFirstIndex(pair.inputCorpus)
 		if found != true {
 			t.Error(
-				"For test ", pair.inputcorpus.WorkID,
+				"For test ", pair.inputCorpus.WorkID,
 				"expected", true,
 				"got", false,
 			)
 		}
-		if pair.inputcorpus.Passages[v].PassageID != pair.inputID {
+		if pair.inputCorpus.Passages[v].PassageID != pair.inputID {
 			t.Error(
-				"For test ", pair.inputcorpus.WorkID,
+				"For test ", pair.inputCorpus.WorkID,
 				"expected", pair.inputID,
-				"got", pair.inputcorpus.Passages[v].PassageID,
+				"got", pair.inputCorpus.Passages[v].PassageID,
 			)
 		}
 	}
 }
 
 func TestSortPassages(t *testing.T) {
-	for j, pair := range URNtests4 {
-		v := gocite.SortPassages(pair.inputcorpus)
-		if v.Ordered == false {
+	/*for j, workTestgroup := range oldURNtests4 { //two runs
+		var tempInputPassages []gocite.Passage
+		for k := range workTestgroup.inputCorpus.Passages { //three runs
+			var tempInputPassage = gocite.Passage{
+				PassageID: workTestgroup.inputCorpus.Passages[k].PassageID,
+				Range:     workTestgroup.inputCorpus.Passages[k].Range,
+				Text:      workTestgroup.inputCorpus.Passages[k].Text,
+				Index:     workTestgroup.inputCorpus.Passages[k].Index,
+				Prev:      workTestgroup.inputCorpus.Passages[k].Prev,
+				Next:      workTestgroup.inputCorpus.Passages[k].Next}
+			tempInputPassages = append(tempInputPassages, tempInputPassage)
+		}
+
+		tempInPutCorpus := gocite.Work{
+			WorkID:   workTestgroup.inputCorpus.WorkID,
+			Passages: tempInputPassages,
+			Ordered:  workTestgroup.inputCorpus.Ordered,
+		}
+
+		sortedWork, err := gocite.SortPassages(tempInPutCorpus)
+		if sortedWork.Ordered == false {
 			t.Error(
-				"For test ", j,
-				"expected", true,
-				"got", false,
+				"For sorting test ", j,
+				" with release 1.0.1 data expected", true,
+				" got ", false, ". Sorting failed.",
 			)
 		}
-		for i := range v.Passages {
-			basePassage := oldTestPassage{PassageID: v.Passages[i].PassageID,
-				Range: v.Passages[i].Range,
-				Text:  v.Passages[i].Text,
-				Index: v.Passages[i].Index,
-				First: v.Passages[i].First,
-				Last:  v.Passages[i].Last,
-				Prev:  v.Passages[i].Prev,
-				Next:  v.Passages[i].Next}
-			comparePassage := oldTestPassage{PassageID: pair.output.Passages[i].PassageID,
-				Range: pair.output.Passages[i].Range,
-				Text:  pair.output.Passages[i].Text,
-				Index: pair.output.Passages[i].Index,
-				First: pair.output.Passages[i].First,
-				Last:  pair.output.Passages[i].Last,
-				Prev:  pair.output.Passages[i].Prev,
-				Next:  pair.output.Passages[i].Next}
+		if err != nil {
+			t.Error("Error calling SortPassages: ", err)
+		}
+
+		for i := range sortedWork.Passages { //should run twice
+			basePassage := newTestPassage{PassageID: sortedWork.Passages[i].PassageID,
+				Range: sortedWork.Passages[i].Range,
+				Text:  sortedWork.Passages[i].Text,
+				Index: sortedWork.Passages[i].Index,
+				Prev:  sortedWork.Passages[i].Prev,
+				Next:  sortedWork.Passages[i].Next}
+			comparePassage := newTestPassage{PassageID: workTestgroup.outputCorpus.Passages[i].PassageID,
+				Range: workTestgroup.outputCorpus.Passages[i].Range,
+				Text:  workTestgroup.outputCorpus.Passages[i].Text,
+				Index: workTestgroup.outputCorpus.Passages[i].Index,
+				Prev:  workTestgroup.outputCorpus.Passages[i].Prev,
+				Next:  workTestgroup.outputCorpus.Passages[i].Next}
 			if basePassage != comparePassage {
 				t.Error(
-					"For test ", j, i,
-					"expected", pair.output.Passages[i],
-					"got", v.Passages[i],
+					"For sorting test ", j, " passage ", i,
+					" with release 1.0.1 data expected ", URNtests4[j].outputCorpus.Passages[i],
+					" got ", sortedWork.Passages[i], " instead",
+				)
+			}
+		}
+	}*/
+
+	for j, workTestgroup := range URNtests4 {
+		work, err := gocite.SortPassages(workTestgroup.inputCorpus) //this could be adapted to account for the occurance of an error.
+		if work.Ordered == false {
+			t.Error(
+				"For sorting test ", j,
+				" with release 2.0.0 data expected", true,
+				" got ", false, ". Sorting failed.",
+			)
+		}
+		if err != nil {
+			t.Error("Error calling SortPassages: ", err)
+		}
+		for i := range work.Passages {
+			basePassage := newTestPassage{PassageID: work.Passages[i].PassageID,
+				Range: work.Passages[i].Range,
+				Text:  work.Passages[i].Text,
+				Index: work.Passages[i].Index,
+				Prev:  work.Passages[i].Prev,
+				Next:  work.Passages[i].Next}
+			comparePassage := newTestPassage{PassageID: workTestgroup.outputCorpus.Passages[i].PassageID,
+				Range: workTestgroup.outputCorpus.Passages[i].Range,
+				Text:  workTestgroup.outputCorpus.Passages[i].Text,
+				Index: workTestgroup.outputCorpus.Passages[i].Index,
+				Prev:  workTestgroup.outputCorpus.Passages[i].Prev,
+				Next:  workTestgroup.outputCorpus.Passages[i].Next}
+			if basePassage != comparePassage {
+				t.Error(
+					"For sorting test ", j, " passage ", i,
+					" with release 2.0.0 data expected ", workTestgroup.outputCorpus.Passages[i],
+					" got ", work.Passages[i], " instead",
 				)
 			}
 		}
@@ -566,11 +637,16 @@ func TestSortPassages(t *testing.T) {
 }
 
 func TestInsertPassage(t *testing.T) {
-	v := gocite.InsertPassage(oldSecondPassage, URNtests5[0].inputcorpus)
+	v, err := gocite.InsertPassage(newSecondPassage, URNtests5[0].inputCorpus)
 	if v.Ordered == true {
 		t.Error(
 			"Expected ordered", false,
 			"got", true,
+		)
+	}
+	if err != nil {
+		t.Error(
+			"Error calling InsertPassage: ", err,
 		)
 	}
 	for i := range v.Passages {
@@ -578,22 +654,18 @@ func TestInsertPassage(t *testing.T) {
 			Range: v.Passages[i].Range,
 			Text:  v.Passages[i].Text,
 			Index: v.Passages[i].Index,
-			First: v.Passages[i].First,
-			Last:  v.Passages[i].Last,
 			Prev:  v.Passages[i].Prev,
 			Next:  v.Passages[i].Next}
-		comparePassage := oldTestPassage{PassageID: URNtests5[0].output.Passages[i].PassageID,
-			Range: URNtests5[0].output.Passages[i].Range,
-			Text:  URNtests5[0].output.Passages[i].Text,
-			Index: URNtests5[0].output.Passages[i].Index,
-			First: URNtests5[0].output.Passages[i].First,
-			Last:  URNtests5[0].output.Passages[i].Last,
-			Prev:  URNtests5[0].output.Passages[i].Prev,
-			Next:  URNtests5[0].output.Passages[i].Next}
+		comparePassage := oldTestPassage{PassageID: URNtests5[0].outputCorpus.Passages[i].PassageID,
+			Range: URNtests5[0].outputCorpus.Passages[i].Range,
+			Text:  URNtests5[0].outputCorpus.Passages[i].Text,
+			Index: URNtests5[0].outputCorpus.Passages[i].Index,
+			Prev:  URNtests5[0].outputCorpus.Passages[i].Prev,
+			Next:  URNtests5[0].outputCorpus.Passages[i].Next}
 		if basePassage != comparePassage {
 			t.Error(
 				"For test", i,
-				"expected", URNtests5[0].output.Passages[i],
+				"expected", URNtests5[0].outputCorpus.Passages[i],
 				"got", v.Passages[i],
 			)
 		}
@@ -706,7 +778,7 @@ var testExtrcorpus = gocite.Work{
 	Ordered: true,
 }
 
-var PassageOne = gocite.Passage{
+var oldPassageOne = oldTestPassage{
 	PassageID: "urn:cts:collection:workgroup.work:1",
 	Range:     false,
 	Text: gocite.EncText{
@@ -719,7 +791,18 @@ var PassageOne = gocite.Passage{
 	Next:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:2", Index: 1},
 }
 
-var PassageTwo = gocite.Passage{
+var PassageOne = gocite.Passage{
+	PassageID: "urn:cts:collection:workgroup.work:1",
+	Range:     false,
+	Text: gocite.EncText{
+		TXT: "This is is the first node.",
+	},
+	Index: 0,
+	Prev:  gocite.PassLoc{},
+	Next:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:2", Index: 1},
+}
+
+var oldPassageTwo = oldTestPassage{
 	PassageID: "urn:cts:collection:workgroup.work:2",
 	Range:     false,
 	Text: gocite.EncText{
@@ -732,7 +815,18 @@ var PassageTwo = gocite.Passage{
 	Next:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:3", Index: 2},
 }
 
-var PassageThree = gocite.Passage{
+var PassageTwo = gocite.Passage{
+	PassageID: "urn:cts:collection:workgroup.work:2",
+	Range:     false,
+	Text: gocite.EncText{
+		TXT: "This is. the second. node.",
+	},
+	Index: 1,
+	Prev:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
+	Next:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:3", Index: 2},
+}
+
+var oldPassageThree = oldTestPassage{
 	PassageID: "urn:cts:collection:workgroup.work:3",
 	Range:     false,
 	Text: gocite.EncText{
@@ -741,6 +835,17 @@ var PassageThree = gocite.Passage{
 	Index: 2,
 	First: gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:1", Index: 0},
 	Last:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:3", Index: 2},
+	Prev:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:2", Index: 1},
+	Next:  gocite.PassLoc{},
+}
+
+var PassageThree = gocite.Passage{
+	PassageID: "urn:cts:collection:workgroup.work:3",
+	Range:     false,
+	Text: gocite.EncText{
+		TXT: "This is the third node.",
+	},
+	Index: 2,
 	Prev:  gocite.PassLoc{Exists: true, PassageID: "urn:cts:collection:workgroup.work:2", Index: 1},
 	Next:  gocite.PassLoc{},
 }

--- a/gocite_test.go
+++ b/gocite_test.go
@@ -3,7 +3,7 @@ package gocite_test
 import (
 	"testing"
 
-	"github.com/ThomasK81/gocite"
+	"gociteDev/gocite"
 )
 
 type oldTestPassage struct {
@@ -229,7 +229,7 @@ var oldTestcorpus2 = oldTestWork{
 	},
 	Ordered: false}
 
-var newTestcorpus2 = gocite.Work{
+var newTestcorpus2 = gocite.Work{ //101
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
 		newFirstPassageChange,
@@ -251,8 +251,20 @@ var oldTestcorpus3 = oldTestWork{
 var newTestcorpus3 = gocite.Work{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
-		{PassageID: newFirstPassageChange.PassageID, Range: newFirstPassageChange.Range, Text: newFirstPassageChange.Text, Index: 0, Next: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}},
-		{PassageID: newThirdPassageChange.PassageID, Range: newThirdPassageChange.Range, Text: newThirdPassageChange.Text, Index: 1, Prev: gocite.PassLoc{Exists: true, PassageID: oldFirstPassage.PassageID, Index: 0}},
+		{PassageID: newFirstPassageChange.PassageID,
+			Range: newFirstPassageChange.Range,
+			Text:  newFirstPassageChange.Text,
+			Index: 0,
+			Next: gocite.PassLoc{Exists: true,
+				PassageID: newThirdPassageChange.PassageID,
+				Index:     1}},
+		{PassageID: newThirdPassageChange.PassageID,
+			Range: newThirdPassageChange.Range,
+			Text:  newThirdPassageChange.Text,
+			Index: 1,
+			Prev: gocite.PassLoc{Exists: true,
+				PassageID: newFirstPassage.PassageID,
+				Index:     0}},
 	},
 	First:   gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0},
 	Last:    gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1},
@@ -291,8 +303,8 @@ var newTestcorpus5 = gocite.Work{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
 		{PassageID: newFirstPassageChange.PassageID, Range: newFirstPassageChange.Range, Text: newFirstPassageChange.Text, Index: 0, Prev: newFirstPassageChange.Prev, Next: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 2}},
-		{PassageID: newThirdPassageChange.PassageID, Range: newThirdPassageChange.Range, Text: newThirdPassageChange.Text, Index: 1, Prev: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 2}, Next: gocite.PassLoc{}},
-		{PassageID: newSecondPassage.PassageID, Range: newSecondPassage.Range, Text: newSecondPassage.Text, Index: 2, Prev: gocite.PassLoc{Exists: true, PassageID: newThirdPassageChange.PassageID, Index: 0}, Next: gocite.PassLoc{Exists: true, PassageID: newThirdPassage.PassageID, Index: 1}},
+		{PassageID: newThirdPassageChange.PassageID, Range: newThirdPassageChange.Range, Text: newThirdPassageChange.Text, Index: 2, Prev: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 2}, Next: gocite.PassLoc{}},
+		{PassageID: newSecondPassage.PassageID, Range: newSecondPassage.Range, Text: newSecondPassage.Text, Index: 1, Prev: gocite.PassLoc{Exists: true, PassageID: newThirdPassageChange.PassageID, Index: 0}, Next: gocite.PassLoc{Exists: true, PassageID: newThirdPassage.PassageID, Index: 1}},
 	},
 	First:   oldFirstPassageChange.First,
 	Last:    oldFirstPassageChange.Last,

--- a/gocite_test.go
+++ b/gocite_test.go
@@ -243,8 +243,26 @@ var newTestcorpus2 = gocite.Work{ //101
 var oldTestcorpus3 = oldTestWork{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []oldTestPassage{
-		{PassageID: oldFirstPassageChange.PassageID, Range: oldFirstPassageChange.Range, Text: oldFirstPassageChange.Text, Index: 0, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}, Next: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}},
-		{PassageID: oldThirdPassageChange.PassageID, Range: oldThirdPassageChange.Range, Text: oldThirdPassageChange.Text, Index: 1, First: gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0}, Last: gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1}, Prev: gocite.PassLoc{Exists: true, PassageID: oldFirstPassage.PassageID, Index: 0}},
+		{PassageID: oldFirstPassageChange.PassageID,
+			Range: oldFirstPassageChange.Range,
+			Text:  oldFirstPassageChange.Text,
+			Index: 0,
+			First: gocite.PassLoc{Exists: true,
+				PassageID: oldFirstPassageChange.PassageID, Index: 0},
+			Last: gocite.PassLoc{Exists: true,
+				PassageID: oldThirdPassageChange.PassageID, Index: 1},
+			Next: gocite.PassLoc{Exists: true,
+				PassageID: oldThirdPassageChange.PassageID, Index: 1}},
+		{PassageID: oldThirdPassageChange.PassageID,
+			Range: oldThirdPassageChange.Range,
+			Text:  oldThirdPassageChange.Text,
+			Index: 1,
+			First: gocite.PassLoc{Exists: true,
+				PassageID: oldFirstPassageChange.PassageID, Index: 0},
+			Last: gocite.PassLoc{Exists: true,
+				PassageID: oldThirdPassageChange.PassageID, Index: 1},
+			Prev: gocite.PassLoc{Exists: true,
+				PassageID: oldFirstPassage.PassageID, Index: 0}},
 	},
 	Ordered: true}
 
@@ -253,18 +271,15 @@ var newTestcorpus3 = gocite.Work{
 	Passages: []gocite.Passage{
 		{PassageID: newFirstPassageChange.PassageID,
 			Range: newFirstPassageChange.Range,
-			Text:  newFirstPassageChange.Text,
-			Index: 0,
+			Text:  newFirstPassageChange.Text, Index: 0,
 			Next: gocite.PassLoc{Exists: true,
-				PassageID: newThirdPassageChange.PassageID,
-				Index:     1}},
+				PassageID: newThirdPassageChange.PassageID, Index: 1}},
 		{PassageID: newThirdPassageChange.PassageID,
 			Range: newThirdPassageChange.Range,
 			Text:  newThirdPassageChange.Text,
 			Index: 1,
 			Prev: gocite.PassLoc{Exists: true,
-				PassageID: newFirstPassage.PassageID,
-				Index:     0}},
+				PassageID: newFirstPassage.PassageID, Index: 0}},
 	},
 	First:   gocite.PassLoc{Exists: true, PassageID: oldFirstPassageChange.PassageID, Index: 0},
 	Last:    gocite.PassLoc{Exists: true, PassageID: oldThirdPassageChange.PassageID, Index: 1},
@@ -293,8 +308,8 @@ var oldTestcorpus5 = oldTestWork{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []oldTestPassage{
 		{PassageID: oldFirstPassageChange.PassageID, Range: oldFirstPassageChange.Range, Text: oldFirstPassageChange.Text, Index: 0, First: oldFirstPassageChange.First, Last: oldFirstPassageChange.Last, Prev: oldFirstPassageChange.Prev, Next: gocite.PassLoc{Exists: true, PassageID: oldSecondPassage.PassageID, Index: 2}},
-		{PassageID: oldThirdPassageChange.PassageID, Range: oldThirdPassageChange.Range, Text: oldThirdPassageChange.Text, Index: 1, First: oldFirstPassageChange.First, Last: oldFirstPassageChange.Last, Prev: gocite.PassLoc{Exists: true, PassageID: oldSecondPassage.PassageID, Index: 2}, Next: gocite.PassLoc{}},
-		{PassageID: oldSecondPassage.PassageID, Range: oldSecondPassage.Range, Text: oldSecondPassage.Text, Index: 2, First: oldThirdPassageChange.First, Last: oldThirdPassageChange.Last, Prev: oldThirdPassageChange.First, Next: gocite.PassLoc{Exists: true, PassageID: oldThirdPassage.PassageID, Index: 1}},
+		{PassageID: oldThirdPassageChange.PassageID, Range: oldThirdPassageChange.Range, Text: oldThirdPassageChange.Text, Index: 2, First: oldFirstPassageChange.First, Last: oldFirstPassageChange.Last, Prev: gocite.PassLoc{Exists: true, PassageID: oldSecondPassage.PassageID, Index: 2}, Next: gocite.PassLoc{}},
+		{PassageID: oldSecondPassage.PassageID, Range: oldSecondPassage.Range, Text: oldSecondPassage.Text, Index: 1, First: oldThirdPassageChange.First, Last: oldThirdPassageChange.Last, Prev: oldThirdPassageChange.First, Next: gocite.PassLoc{Exists: true, PassageID: oldThirdPassage.PassageID, Index: 1}},
 	},
 	Ordered: false,
 }
@@ -304,7 +319,7 @@ var newTestcorpus5 = gocite.Work{
 	Passages: []gocite.Passage{
 		{PassageID: newFirstPassageChange.PassageID, Range: newFirstPassageChange.Range, Text: newFirstPassageChange.Text, Index: 0, Prev: newFirstPassageChange.Prev, Next: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 2}},
 		{PassageID: newThirdPassageChange.PassageID, Range: newThirdPassageChange.Range, Text: newThirdPassageChange.Text, Index: 2, Prev: gocite.PassLoc{Exists: true, PassageID: newSecondPassage.PassageID, Index: 2}, Next: gocite.PassLoc{}},
-		{PassageID: newSecondPassage.PassageID, Range: newSecondPassage.Range, Text: newSecondPassage.Text, Index: 1, Prev: gocite.PassLoc{Exists: true, PassageID: newThirdPassageChange.PassageID, Index: 0}, Next: gocite.PassLoc{Exists: true, PassageID: newThirdPassage.PassageID, Index: 1}},
+		{PassageID: newSecondPassage.PassageID, Range: newSecondPassage.Range, Text: newSecondPassage.Text, Index: 1, Prev: gocite.PassLoc{Exists: true, PassageID: newFirstPassageChange.PassageID, Index: 0}, Next: gocite.PassLoc{Exists: true, PassageID: newThirdPassage.PassageID, Index: 1}},
 	},
 	First:   oldFirstPassageChange.First,
 	Last:    oldFirstPassageChange.Last,
@@ -344,7 +359,7 @@ var oldTestcorpus7 = oldTestWork{
 var newTestcorpus7 = gocite.Work{
 	WorkID: "urn:cts:collection:workgroup.work:",
 	Passages: []gocite.Passage{
-		{PassageID: newFirstPassageChange.PassageID, Range: false, Text: newFirstPassageChange.Text, Index: 0, Next: gocite.PassLoc{Exists: true, PassageID: newThirdPassage.PassageID, Index: 1}},
+		{PassageID: newFirstPassageChange.PassageID, Range: false, Text: newFirstPassageChange.Text, Index: 0, Next: gocite.PassLoc{Exists: true, PassageID: newThirdPassageChange.PassageID, Index: 1}},
 		{PassageID: newThirdPassageChange.PassageID, Range: false, Text: newThirdPassageChange.Text, Index: 1, Prev: gocite.PassLoc{Exists: true, PassageID: newFirstPassageChange.PassageID, Index: 0}},
 	},
 	First:   gocite.PassLoc{Exists: true, PassageID: newFirstPassageChange.PassageID, Index: 0},
@@ -558,7 +573,8 @@ func TestFindFirstIndex(t *testing.T) {
 }
 
 func TestSortPassages(t *testing.T) {
-	/*for j, workTestgroup := range oldURNtests4 { //two runs
+	/*Sorting passages with the old format should be possible. Does not work yet (runs into endless loop)
+	for j, workTestgroup := range oldURNtests4 { //two runs
 		var tempInputPassages []gocite.Passage
 		for k := range workTestgroup.inputCorpus.Passages { //three runs
 			var tempInputPassage = gocite.Passage{
@@ -649,8 +665,8 @@ func TestSortPassages(t *testing.T) {
 }
 
 func TestInsertPassage(t *testing.T) {
-	v, err := gocite.InsertPassage(newSecondPassage, URNtests5[0].inputCorpus)
-	if v.Ordered == true {
+	insertedWork, err := gocite.InsertPassage(newSecondPassage, URNtests5[0].inputCorpus)
+	if insertedWork.Ordered == true {
 		t.Error(
 			"Expected ordered", false,
 			"got", true,
@@ -661,13 +677,13 @@ func TestInsertPassage(t *testing.T) {
 			"Error calling InsertPassage: ", err,
 		)
 	}
-	for i := range v.Passages {
-		basePassage := oldTestPassage{PassageID: v.Passages[i].PassageID,
-			Range: v.Passages[i].Range,
-			Text:  v.Passages[i].Text,
-			Index: v.Passages[i].Index,
-			Prev:  v.Passages[i].Prev,
-			Next:  v.Passages[i].Next}
+	for i := range insertedWork.Passages {
+		basePassage := oldTestPassage{PassageID: insertedWork.Passages[i].PassageID,
+			Range: insertedWork.Passages[i].Range,
+			Text:  insertedWork.Passages[i].Text,
+			Index: insertedWork.Passages[i].Index,
+			Prev:  insertedWork.Passages[i].Prev,
+			Next:  insertedWork.Passages[i].Next}
 		comparePassage := oldTestPassage{PassageID: URNtests5[0].outputCorpus.Passages[i].PassageID,
 			Range: URNtests5[0].outputCorpus.Passages[i].Range,
 			Text:  URNtests5[0].outputCorpus.Passages[i].Text,
@@ -678,7 +694,7 @@ func TestInsertPassage(t *testing.T) {
 			t.Error(
 				"For test", i,
 				"expected", URNtests5[0].outputCorpus.Passages[i],
-				"got", v.Passages[i],
+				"got", insertedWork.Passages[i],
 			)
 		}
 	}


### PR DESCRIPTION
¡Work should be continued as soon as possible!
Fixed two issues in gocite.SortPassages and an issue in gocite_test.(new/old)Testcorpus5 (See 59fe0d8)
All tests but TestExtractTextByID work, mostly with new format

Todos: 
test_SortPassages should be finished to test passages with old format
TestExtractTextByID has to be finished to work with new format
All tests should be run with old format data as well (most could be transferred to new format with sortPassages)
All test cases should be integrated into tests (for example: Empty passage at beginning or end, inserting passages at beginning or end)
possibly simplifying test format (working with less testCorpora, always use the same order (First, Last and Prev, Next))
exchange one-letter variables for speaking variables that reflect their purpose
Cleaning